### PR TITLE
Setup bump

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -5,6 +5,10 @@ inputs:
     description: 'Version of Java to use'
     required: false
     default: 11
+  java-distribution:
+    description: 'The Java distribution to install'
+    required: false
+    default: 'zulu'
 
 
 runs:
@@ -14,6 +18,7 @@ runs:
       uses: actions/setup-java@v3
       with:
         java-version: ${{ inputs.java-version }}
+        java-distribution: ${{ inputs.java-distribution }}
     - name: Install slice2java
       run: |
         sudo apt-get install -y libmcpp-dev

--- a/action.yml
+++ b/action.yml
@@ -11,7 +11,7 @@ runs:
   using: "composite"
   steps:
     - name: Set up JDK ${{ inputs.java-version }}
-      uses: actions/setup-java@v1
+      uses: actions/setup-java@v3
       with:
         java-version: ${{ inputs.java-version }}
     - name: Install slice2java

--- a/action.yml
+++ b/action.yml
@@ -25,7 +25,7 @@ runs:
         echo "/opt/ice-3.6.5/bin" >> $GITHUB_PATH
       shell: bash
     - name: Install Python 3.8
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: 3.8
     - name: Install Ice Python binding


### PR DESCRIPTION
Java v1 uses the deprecated ``set-output`` command
This PR bumps to version v3 https://github.com/actions/setup-java
and adds option to configure the ``distribution`` (required by  actions/setup-java)

Also bump ``setup-python`` to v4
